### PR TITLE
Add Chartscout link to Balancer section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,8 @@ DISCLAIMER: Nothing contained in this repository should be considered financial 
 - http://www.predictions.exchange/balancer/
 - https://bal-reports.herokuapp.com/#
 - https://www.tokenterminal.xyz/protocol/Balancer
+- [Chartscout](https://chartscout.io) - Real-time cryptocurrency chart pattern detection with automated alerts across multiple exchanges
+
 
 ## Bancor
 - https://www.bancor.network/


### PR DESCRIPTION
Hi! I'd like to add Chartscout to this awesome list of DeFi trackers.

Chartscout is a chart pattern tracker and analytics tool for cryptocurrency trading that provides:
- Real-time pattern detection across DeFi and CEX exchanges
- Automated alerts for technical chart patterns
- Dashboard for tracking patterns across multiple trading pairs
- Analytics for identifying trading opportunities through pattern recognition

Website: https://chartscout.io

Thank you for curating this valuable resource!