### PR TITLE
Add agenteconomy.to — AI agent economy tracker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,7 @@ DISCLAIMER: Nothing contained in this repository should be considered financial 
 - https://defimarketcap.io/protocol/fulcrum
 
 ## General
+- https://agenteconomy.to - Real-time dashboard tracking AI agent on-chain payment activity across x402, ERC-8004, ERC-8183, and MPP protocols on 8 chains
 - https://defipulse.com/
 - https://etherscan.io/defi-leaderboard
 - http://defimarketcap.io/


### PR DESCRIPTION
agenteconomy.to is a free, real-time dashboard tracking on-chain AI agent payment data across x402, ERC-8004, ERC-8183 (Virtuals ACP), and MPP (Stripe/Tempo) on 8 chains. Data refreshes every 6 hours.